### PR TITLE
Switch to fastmcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server for performing read-only operations against Snowflake databases. This tool enables Claude to securely query Snowflake data without modifying any information.
 
+This server uses **FastMCP** for lightweight tool registration and execution (이 서버는 빠른 MCP 도구 등록과 실행을 위해 **FastMCP**를 사용합니다).
+
 ## Features
 
 - Flexible authentication to Snowflake using either:
@@ -12,6 +14,7 @@ A Model Context Protocol (MCP) server for performing read-only operations agains
 - Support for multiple SQL statement types (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH)
 - MCP-compatible handlers for querying Snowflake data
 - Read-only operations with security checks to prevent data modification
+- Uses **FastMCP** for lightweight tool registration and execution (빠른 MCP 도구 등록과 실행을 위해 FastMCP 사용)
 - Support for Python 3.12+
 - Stdio-based MCP server for easy integration with Claude Desktop
 
@@ -200,5 +203,6 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 This project uses:
 - [Snowflake Connector Python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector) for connecting to Snowflake
 - [MCP (Model Context Protocol)](https://github.com/anthropics/anthropic-cookbook/tree/main/mcp) for interacting with Claude
+- [FastMCP](https://github.com/anthropics/anthropic-cookbook/tree/main/mcp/fastmcp) for lightweight tool registration and server execution
 - [Pydantic](https://docs.pydantic.dev/) for data validation
 - [python-dotenv](https://github.com/theskumar/python-dotenv) for environment variable management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "cryptography>=41.0.0",
     "mcp",
+    "fastmcp",
     "anyio>=3.7.1",
     "sqlglot>=11.5.5"
 ]

--- a/snowflake_mcp_server/main.py
+++ b/snowflake_mcp_server/main.py
@@ -11,14 +11,12 @@ Claude with secure, controlled access to Snowflake data for analysis and reporti
 """
 
 import os
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
-import anyio
 import mcp.types as mcp_types
 import sqlglot
 from dotenv import load_dotenv
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
+from fastmcp import FastMCP
 from sqlglot.errors import ParseError
 
 from snowflake_mcp_server.utils.snowflake_conn import (
@@ -65,23 +63,12 @@ def init_connection_manager() -> None:
     connection_manager.initialize(config)
 
 
-# Define MCP server
-def create_server() -> Server:
-    """Create and configure the MCP server."""
-    # Initialize the connection manager before setting up the server
-    init_connection_manager()
-
-    server: Server = Server(
-        name="snowflake-mcp-server",
-        version="0.2.0",
-        instructions="MCP server for performing read-only operations against "
-        "Snowflake.",
-    )
-
-    return server
-
+# Initialize connection manager and FastMCP instance before defining tools
+init_connection_manager()
+mcp = FastMCP("snowflake-mcp-server")
 
 # Snowflake query handler functions
+@mcp.tool()
 async def handle_list_databases(
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
@@ -120,6 +107,7 @@ async def handle_list_databases(
         ]
 
 
+@mcp.tool()
 async def handle_list_views(
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
@@ -194,6 +182,7 @@ async def handle_list_views(
         ]
 
 
+@mcp.tool()
 async def handle_describe_view(
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
@@ -280,6 +269,7 @@ async def handle_describe_view(
         ]
 
 
+@mcp.tool()
 async def handle_query_view(
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
@@ -375,6 +365,7 @@ async def handle_query_view(
         ]
 
 
+@mcp.tool()
 async def handle_execute_query(
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
@@ -511,142 +502,4 @@ async def handle_execute_query(
 # Function to run the server with stdio interface
 def run_stdio_server() -> None:
     """Run the MCP server using stdin/stdout for communication."""
-
-    async def run() -> None:
-        server = create_server()
-
-        # Register all the Snowflake tools
-        @server.call_tool()
-        async def call_tool(
-            name: str, arguments: Optional[Dict[str, Any]] = None
-        ) -> Sequence[
-            Union[
-                mcp_types.TextContent,
-                mcp_types.ImageContent,
-                mcp_types.EmbeddedResource,
-            ]
-        ]:
-            if name == "list_databases":
-                return await handle_list_databases(name, arguments)
-            elif name == "list_views":
-                return await handle_list_views(name, arguments)
-            elif name == "describe_view":
-                return await handle_describe_view(name, arguments)
-            elif name == "query_view":
-                return await handle_query_view(name, arguments)
-            elif name == "execute_query":
-                return await handle_execute_query(name, arguments)
-            else:
-                return [
-                    mcp_types.TextContent(type="text", text=f"Unknown tool: {name}")
-                ]
-
-        # Create tool definitions for all Snowflake tools
-        @server.list_tools()
-        async def list_tools() -> List[mcp_types.Tool]:
-            return [
-                mcp_types.Tool(
-                    name="list_databases",
-                    description="List all accessible Snowflake databases",
-                    inputSchema={"type": "object", "properties": {}, "required": []},
-                ),
-                mcp_types.Tool(
-                    name="list_views",
-                    description="List all views in a specified database and schema",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "database": {
-                                "type": "string",
-                                "description": "The database name (required)",
-                            },
-                            "schema": {
-                                "type": "string",
-                                "description": "The schema name (optional, will use current schema if not provided)",
-                            },
-                        },
-                        "required": ["database"],
-                    },
-                ),
-                mcp_types.Tool(
-                    name="describe_view",
-                    description="Get detailed information about a specific view including columns and SQL definition",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "database": {
-                                "type": "string",
-                                "description": "The database name (required)",
-                            },
-                            "schema": {
-                                "type": "string",
-                                "description": "The schema name (optional, will use current schema if not provided)",
-                            },
-                            "view_name": {
-                                "type": "string",
-                                "description": "The name of the view to describe (required)",
-                            },
-                        },
-                        "required": ["database", "view_name"],
-                    },
-                ),
-                mcp_types.Tool(
-                    name="query_view",
-                    description="Query data from a view with an optional row limit",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "database": {
-                                "type": "string",
-                                "description": "The database name (required)",
-                            },
-                            "schema": {
-                                "type": "string",
-                                "description": "The schema name (optional, will use current schema if not provided)",
-                            },
-                            "view_name": {
-                                "type": "string",
-                                "description": "The name of the view to query (required)",
-                            },
-                            "limit": {
-                                "type": "integer",
-                                "description": "Maximum number of rows to return (default: 10)",
-                            },
-                        },
-                        "required": ["database", "view_name"],
-                    },
-                ),
-                mcp_types.Tool(
-                    name="execute_query",
-                    description="Execute a read-only SQL query against Snowflake",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "query": {
-                                "type": "string",
-                                "description": "The SQL query to execute (supports SELECT, SHOW, DESCRIBE, EXPLAIN, and WITH statements)",
-                            },
-                            "database": {
-                                "type": "string",
-                                "description": "The database to use (optional)",
-                            },
-                            "schema": {
-                                "type": "string",
-                                "description": "The schema to use (optional)",
-                            },
-                            "limit": {
-                                "type": "integer",
-                                "description": "Maximum number of rows to return (default: 100)",
-                            },
-                        },
-                        "required": ["query"],
-                    },
-                ),
-            ]
-
-        init_options = server.create_initialization_options()
-
-        async with stdio_server() as (read_stream, write_stream):
-            await server.run(read_stream, write_stream, init_options)
-
-    anyio.run(run)
+    mcp.run()

--- a/snowflake_mcp_server/utils/template.py
+++ b/snowflake_mcp_server/utils/template.py
@@ -9,10 +9,8 @@ from typing import Any, Dict, List
 
 import mcp.types as mcp_types
 
-from mcp_server_snowflake.main import get_snowflake_config
-from mcp_server_snowflake.utils.snowflake_conn import (
-    get_snowflake_connection,
-)
+from snowflake_mcp_server.main import get_snowflake_config
+from snowflake_mcp_server.utils.snowflake_conn import get_snowflake_connection
 
 
 async def template_simple_query(

--- a/tests/test_snowflake_conn.py
+++ b/tests/test_snowflake_conn.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from mcp_server_snowflake.utils.snowflake_conn import (
+from snowflake_mcp_server.utils.snowflake_conn import (
     AuthType,
     SnowflakeConfig,
     get_snowflake_connection,
@@ -47,7 +47,7 @@ def snowflake_config_browser() -> SnowflakeConfig:
     )
 
 
-@patch("mcp_server_snowflake.utils.snowflake_conn.load_private_key")
+@patch("snowflake_mcp_server.utils.snowflake_conn.load_private_key")
 @patch("snowflake.connector.connect")
 def test_get_snowflake_connection_private_key(
     mock_connect: MagicMock,


### PR DESCRIPTION
## Summary
- add `fastmcp` dependency
- migrate server logic in `main.py` to use `FastMCP`
- decorate Snowflake handlers with `@mcp.tool`
- simplify `run_stdio_server`
- fix import paths and document FastMCP usage in README

## Testing
- `ruff check .`
- `mypy snowflake_mcp_server` *(fails: Cannot find implementation or library stub for modules)*
- `pytest -q` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.